### PR TITLE
feat: scaffold orion-cli with Cobra, Gemini adapter, and GitHub issue creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# orion-cli
+
+Doğal dilde verilen geliştirme görevlerini analiz edip GitHub Issue'larına dönüştüren CLI.
+
+## Kurulum (adım adım)
+
+```bash
+mkdir orion-cli
+cd orion-cli
+
+go mod init orion-cli
+go get github.com/spf13/cobra@latest
+go get github.com/google/go-github/v66/github@latest
+go get golang.org/x/oauth2@latest
+```
+
+## Klasör yapısı
+
+```text
+.
+├── cmd/
+│   ├── root.go
+│   └── task.go
+├── internal/
+│   ├── ai/
+│   │   └── gemini_adapter.go
+│   ├── config/
+│   │   └── env.go
+│   ├── core/
+│   │   ├── facade.go
+│   │   ├── ports.go
+│   │   └── types.go
+│   ├── github/
+│   │   └── issues_adapter.go
+│   └── gitrepo/
+│       └── detector.go
+├── main.go
+├── go.mod
+└── README.md
+```
+
+## Kullanım
+
+Önce ortam değişkenlerini tanımlayın:
+
+```bash
+export GEMINI_API_KEY="..."
+export GITHUB_TOKEN="..."
+```
+
+Çalıştırma:
+
+```bash
+go run . task "Kullanıcı kayıt olduğunda RabbitMQ'ya mesaj atacak bir servis yazacağım, bunu planla"
+```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,12 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var rootCmd = &cobra.Command{
+	Use:   "orion-cli",
+	Short: "AI destekli görevleri GitHub Issue'larına dönüştürür",
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}

--- a/cmd/task.go
+++ b/cmd/task.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"orion-cli/internal/ai"
+	"orion-cli/internal/config"
+	"orion-cli/internal/core"
+	githubadapter "orion-cli/internal/github"
+	"orion-cli/internal/gitrepo"
+)
+
+func init() {
+	rootCmd.AddCommand(taskCmd)
+}
+
+var taskCmd = &cobra.Command{
+	Use:   "task [gorev_metni]",
+	Short: "Doğal dil görevini analiz edip GitHub issue'ları açar",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		env, err := config.LoadEnv()
+		if err != nil {
+			return err
+		}
+
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("çalışma dizini alınamadı: %w", err)
+		}
+
+		analyzer := ai.NewGeminiAdapter(env.GeminiAPIKey, env.GeminiModel, nil)
+		creator := githubadapter.NewIssuesAdapter(env.GitHubToken)
+		locator := gitrepo.NewDetector(wd)
+
+		facade := core.NewTaskFacade(analyzer, creator, locator)
+		createdIssues, err := facade.Execute(args[0])
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("✅ Issue'lar başarıyla oluşturuldu:")
+		for _, issue := range createdIssues {
+			fmt.Printf("- #%d %s -> %s\n", issue.Number, issue.Title, issue.URL)
+		}
+		return nil
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module orion-cli
+
+go 1.22
+
+require (
+	github.com/google/go-github/v66 v66.0.0
+	github.com/spf13/cobra v1.8.1
+	golang.org/x/oauth2 v0.24.0
+)

--- a/internal/ai/gemini_adapter.go
+++ b/internal/ai/gemini_adapter.go
@@ -1,0 +1,114 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"orion-cli/internal/core"
+)
+
+const systemPrompt = "Sen bir Technical Product Manager'sın. Verilen metni incele ve bana sadece aşağıdaki JSON formatında bir görev listesi dön. Markdown kullanma, sadece saf JSON dön."
+
+type GeminiAdapter struct {
+	apiKey string
+	model  string
+	client *http.Client
+}
+
+func NewGeminiAdapter(apiKey, model string, client *http.Client) *GeminiAdapter {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &GeminiAdapter{apiKey: apiKey, model: model, client: client}
+}
+
+func (g *GeminiAdapter) Analyze(text string) ([]core.IssueDraft, error) {
+	return g.AnalyzeWithContext(context.Background(), text)
+}
+
+func (g *GeminiAdapter) AnalyzeWithContext(ctx context.Context, text string) ([]core.IssueDraft, error) {
+	endpoint := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s", g.model, g.apiKey)
+
+	payload := map[string]any{
+		"system_instruction": map[string]any{
+			"parts": []map[string]string{{"text": systemPrompt}},
+		},
+		"contents": []map[string]any{{
+			"role":  "user",
+			"parts": []map[string]string{{"text": text}},
+		}},
+		"generationConfig": map[string]any{
+			"temperature":      0.2,
+			"responseMimeType": "application/json",
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("gemini isteği oluşturulamadı: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("gemini isteği hazırlanamadı: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("gemini API çağrısı başarısız: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("gemini cevabı okunamadı: %w", err)
+	}
+
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("gemini API hata döndü (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var parsed struct {
+		Candidates []struct {
+			Content struct {
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"content"`
+		} `json:"candidates"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("gemini cevabı parse edilemedi: %w", err)
+	}
+
+	if len(parsed.Candidates) == 0 || len(parsed.Candidates[0].Content.Parts) == 0 {
+		return nil, fmt.Errorf("gemini boş cevap döndü")
+	}
+
+	jsonText := sanitizeJSON(parsed.Candidates[0].Content.Parts[0].Text)
+
+	var drafts []core.IssueDraft
+	if err := json.Unmarshal([]byte(jsonText), &drafts); err != nil {
+		return nil, fmt.Errorf("gemini çıktısı JSON değil: %w, içerik: %s", err, jsonText)
+	}
+
+	if len(drafts) == 0 {
+		return nil, fmt.Errorf("gemini görev listesi üretmedi")
+	}
+
+	return drafts, nil
+}
+
+func sanitizeJSON(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	trimmed = strings.TrimPrefix(trimmed, "```json")
+	trimmed = strings.TrimPrefix(trimmed, "```")
+	trimmed = strings.TrimSuffix(trimmed, "```")
+	return strings.TrimSpace(trimmed)
+}

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+type Env struct {
+	GeminiAPIKey string
+	GitHubToken  string
+	GeminiModel  string
+}
+
+func LoadEnv() (Env, error) {
+	env := Env{
+		GeminiAPIKey: os.Getenv("GEMINI_API_KEY"),
+		GitHubToken:  os.Getenv("GITHUB_TOKEN"),
+		GeminiModel:  os.Getenv("GEMINI_MODEL"),
+	}
+
+	if env.GeminiModel == "" {
+		env.GeminiModel = "gemini-2.5-flash"
+	}
+
+	if env.GeminiAPIKey == "" {
+		return Env{}, fmt.Errorf("GEMINI_API_KEY eksik. Örnek: export GEMINI_API_KEY='your_api_key'")
+	}
+	if env.GitHubToken == "" {
+		return Env{}, fmt.Errorf("GITHUB_TOKEN eksik. Örnek: export GITHUB_TOKEN='ghp_xxx'")
+	}
+
+	return env, nil
+}

--- a/internal/core/facade.go
+++ b/internal/core/facade.go
@@ -1,0 +1,36 @@
+package core
+
+import "fmt"
+
+type TaskFacade struct {
+	Analyzer TaskAnalyzer
+	Creator  IssueCreator
+	Locator  RepoLocator
+}
+
+func NewTaskFacade(analyzer TaskAnalyzer, creator IssueCreator, locator RepoLocator) *TaskFacade {
+	return &TaskFacade{Analyzer: analyzer, Creator: creator, Locator: locator}
+}
+
+func (f *TaskFacade) Execute(taskText string) ([]CreatedIssue, error) {
+	if taskText == "" {
+		return nil, fmt.Errorf("görev metni boş olamaz")
+	}
+
+	owner, repo, err := f.Locator.DetectOwnerRepo()
+	if err != nil {
+		return nil, err
+	}
+
+	drafts, err := f.Analyzer.Analyze(taskText)
+	if err != nil {
+		return nil, err
+	}
+
+	created, err := f.Creator.CreateIssues(owner, repo, drafts)
+	if err != nil {
+		return nil, err
+	}
+
+	return created, nil
+}

--- a/internal/core/ports.go
+++ b/internal/core/ports.go
@@ -1,0 +1,13 @@
+package core
+
+type TaskAnalyzer interface {
+	Analyze(text string) ([]IssueDraft, error)
+}
+
+type IssueCreator interface {
+	CreateIssues(owner, repo string, drafts []IssueDraft) ([]CreatedIssue, error)
+}
+
+type RepoLocator interface {
+	DetectOwnerRepo() (string, string, error)
+}

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -1,0 +1,13 @@
+package core
+
+type IssueDraft struct {
+	Title  string   `json:"title"`
+	Body   string   `json:"body"`
+	Labels []string `json:"labels"`
+}
+
+type CreatedIssue struct {
+	Number int
+	URL    string
+	Title  string
+}

--- a/internal/github/issues_adapter.go
+++ b/internal/github/issues_adapter.go
@@ -1,0 +1,46 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	gh "github.com/google/go-github/v66/github"
+	"golang.org/x/oauth2"
+
+	"orion-cli/internal/core"
+)
+
+type IssuesAdapter struct {
+	client *gh.Client
+}
+
+func NewIssuesAdapter(token string) *IssuesAdapter {
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	httpClient := oauth2.NewClient(context.Background(), tokenSource)
+	return &IssuesAdapter{client: gh.NewClient(httpClient)}
+}
+
+func (a *IssuesAdapter) CreateIssues(owner, repo string, drafts []core.IssueDraft) ([]core.CreatedIssue, error) {
+	result := make([]core.CreatedIssue, 0, len(drafts))
+
+	for _, draft := range drafts {
+		issueReq := &gh.IssueRequest{
+			Title:  gh.Ptr(draft.Title),
+			Body:   gh.Ptr(draft.Body),
+			Labels: &draft.Labels,
+		}
+
+		issue, _, err := a.client.Issues.Create(context.Background(), owner, repo, issueReq)
+		if err != nil {
+			return nil, fmt.Errorf("issue oluşturulamadı (%s): %w", draft.Title, err)
+		}
+
+		result = append(result, core.CreatedIssue{
+			Number: issue.GetNumber(),
+			URL:    issue.GetHTMLURL(),
+			Title:  issue.GetTitle(),
+		})
+	}
+
+	return result, nil
+}

--- a/internal/gitrepo/detector.go
+++ b/internal/gitrepo/detector.go
@@ -1,0 +1,80 @@
+package gitrepo
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type Detector struct {
+	workdir string
+}
+
+func NewDetector(workdir string) *Detector {
+	if workdir == "" {
+		workdir, _ = os.Getwd()
+	}
+	return &Detector{workdir: workdir}
+}
+
+func (d *Detector) DetectOwnerRepo() (string, string, error) {
+	configPath := filepath.Join(d.workdir, ".git", "config")
+	file, err := os.Open(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", "", fmt.Errorf("bu klasörde git reposu bulunamadı (.git/config yok)")
+		}
+		return "", "", fmt.Errorf(".git/config okunamadı: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	insideOrigin := false
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "[") {
+			insideOrigin = strings.EqualFold(line, "[remote \"origin\"]")
+			continue
+		}
+		if !insideOrigin || !strings.HasPrefix(strings.ToLower(line), "url") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		owner, repo, err := parseRemoteURL(strings.TrimSpace(parts[1]))
+		if err != nil {
+			return "", "", err
+		}
+		return owner, repo, nil
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", "", fmt.Errorf(".git/config taranamadı: %w", err)
+	}
+
+	return "", "", fmt.Errorf("origin remote bulunamadı")
+}
+
+var patterns = []*regexp.Regexp{
+	regexp.MustCompile(`^https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$`),
+	regexp.MustCompile(`^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$`),
+	regexp.MustCompile(`^ssh://git@github\.com/([^/]+)/([^/]+?)(?:\.git)?$`),
+}
+
+func parseRemoteURL(remote string) (string, string, error) {
+	for _, p := range patterns {
+		match := p.FindStringSubmatch(remote)
+		if len(match) == 3 {
+			return match[1], match[2], nil
+		}
+	}
+	return "", "", fmt.Errorf("origin URL GitHub formatında değil: %s", remote)
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"log"
+
+	"orion-cli/cmd"
+)
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a CLI (`orion-cli`) that converts natural-language development tasks into GitHub Issues using an LLM, with a focused, testable architecture.
- Use clean, modular boundaries and design patterns (Adapter for AI/GitHub, Facade for orchestration) to keep components replaceable and easy to test.
- Automate environment validation (`GEMINI_API_KEY`, `GITHUB_TOKEN`) and repository detection so the tool works with minimal user setup.

### Description
- Added Cobra-based CLI (`cmd/root.go`, `cmd/task.go`) with `task` subcommand that drives the flow and prints created Issue URLs.
- Implemented AI adapter `internal/ai/gemini_adapter.go` that calls Google Gemini (`generateContent`) with the required system prompt and parses the returned JSON into `core.IssueDraft` structs.
- Implemented GitHub adapter `internal/github/issues_adapter.go` using `go-github` and OAuth2 to create issues from drafts and return `core.CreatedIssue` metadata.
- Implemented Git repo detector `internal/gitrepo/detector.go` which reads `.git/config` and extracts `owner/repo` from `origin` URLs (supports HTTPS/SSH formats).
- Added core abstractions in `internal/core` (`ports.go`, `types.go`) and a `TaskFacade` (`internal/core/facade.go`) that orchestrates detection -> analysis -> issue creation.
- Added environment loader `internal/config/env.go` that validates `GEMINI_API_KEY` and `GITHUB_TOKEN` and sets default `GEMINI_MODEL` to `gemini-2.5-flash` if unset.
- Added `main.go`, `go.mod` and `README.md` documenting setup steps (`go mod init`/`go get`) and usage example.

### Testing
- Ran `gofmt -w` across the repository, which completed successfully to ensure consistent formatting.
- Ran `go mod tidy` and `GOPROXY=direct go mod tidy`, both failed due to network/proxy restrictions when downloading external modules (received 403 errors), preventing module checksum generation.
- Ran `go test ./...`, which failed because `go.sum` entries could not be created due to the dependency download restrictions described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c28e7ae288330805cbe2576db25da)