### PR TITLE
Sanitize env tokens, avoid leaking Gemini API key, and fix GitHub issue helper

### DIFF
--- a/internal/ai/gemini_adapter.go
+++ b/internal/ai/gemini_adapter.go
@@ -32,7 +32,7 @@ func (g *GeminiAdapter) Analyze(text string) ([]core.IssueDraft, error) {
 }
 
 func (g *GeminiAdapter) AnalyzeWithContext(ctx context.Context, text string) ([]core.IssueDraft, error) {
-	endpoint := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s", g.model, g.apiKey)
+	endpoint := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent", g.model)
 
 	payload := map[string]any{
 		"system_instruction": map[string]any{
@@ -58,6 +58,7 @@ func (g *GeminiAdapter) AnalyzeWithContext(ctx context.Context, text string) ([]
 		return nil, fmt.Errorf("gemini isteği hazırlanamadı: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-api-key", g.apiKey)
 
 	resp, err := g.client.Do(req)
 	if err != nil {

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 type Env struct {
@@ -13,9 +14,9 @@ type Env struct {
 
 func LoadEnv() (Env, error) {
 	env := Env{
-		GeminiAPIKey: os.Getenv("GEMINI_API_KEY"),
-		GitHubToken:  os.Getenv("GITHUB_TOKEN"),
-		GeminiModel:  os.Getenv("GEMINI_MODEL"),
+		GeminiAPIKey: sanitizeEnvValue(os.Getenv("GEMINI_API_KEY")),
+		GitHubToken:  sanitizeEnvValue(os.Getenv("GITHUB_TOKEN")),
+		GeminiModel:  sanitizeEnvValue(os.Getenv("GEMINI_MODEL")),
 	}
 
 	if env.GeminiModel == "" {
@@ -30,4 +31,16 @@ func LoadEnv() (Env, error) {
 	}
 
 	return env, nil
+}
+
+func sanitizeEnvValue(v string) string {
+	trimmed := strings.TrimSpace(v)
+	if len(trimmed) >= 2 {
+		if (trimmed[0] == '\'' && trimmed[len(trimmed)-1] == '\'') ||
+			(trimmed[0] == '"' && trimmed[len(trimmed)-1] == '"') ||
+			(trimmed[0] == '`' && trimmed[len(trimmed)-1] == '`') {
+			return strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+		}
+	}
+	return strings.Trim(trimmed, "'\"")
 }

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1,0 +1,27 @@
+package config
+
+import "testing"
+
+func TestSanitizeEnvValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "plain", input: "AIzaSy123", want: "AIzaSy123"},
+		{name: "single quoted", input: "'AIzaSy123'", want: "AIzaSy123"},
+		{name: "double quoted", input: "\"ghp_token\"", want: "ghp_token"},
+		{name: "backtick quoted", input: "`gemini-2.5-flash`", want: "gemini-2.5-flash"},
+		{name: "dangling single quote", input: "AIzaSy123'", want: "AIzaSy123"},
+		{name: "spaces and quote", input: "  ' ghp_token '  ", want: "ghp_token"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeEnvValue(tt.input)
+			if got != tt.want {
+				t.Fatalf("sanitizeEnvValue(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/github/issues_adapter.go
+++ b/internal/github/issues_adapter.go
@@ -25,8 +25,8 @@ func (a *IssuesAdapter) CreateIssues(owner, repo string, drafts []core.IssueDraf
 
 	for _, draft := range drafts {
 		issueReq := &gh.IssueRequest{
-			Title:  gh.Ptr(draft.Title),
-			Body:   gh.Ptr(draft.Body),
+			Title:  gh.String(draft.Title),
+			Body:   gh.String(draft.Body),
 			Labels: &draft.Labels,
 		}
 

--- a/main.go
+++ b/main.go
@@ -1,13 +1,15 @@
 package main
 
 import (
-	"log"
+	"fmt"
+	"os"
 
 	"orion-cli/cmd"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		log.Fatal(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
### Motivation
- Prevent accidental leakage of API keys/tokens (Gemini key was exposed in URL or via fatal logger output) and remove temporary debug prints that could surface secrets.
- Clean up malformed environment values (trailing or surrounding quotes) so token parsing does not produce stray characters like a trailing single quote.
- Ensure compatibility with `go-github v66` helper names used when creating issues.

### Description
- Replaced `log.Fatal(err)` in `main.go` with explicit `fmt.Fprintln(os.Stderr, err)` and `os.Exit(1)` to avoid the logger emitting unintended content to stdout/stderr.
- Added `sanitizeEnvValue` in `internal/config/env.go` and use it when reading `GEMINI_API_KEY`, `GITHUB_TOKEN`, and `GEMINI_MODEL` to trim whitespace and surrounding/dangling quotes.
- Updated `internal/ai/gemini_adapter.go` to stop placing the API key in the request URL and instead set the `x-goog-api-key` header to avoid exposing the key in transport-level errors or logs.
- Added unit tests in `internal/config/env_test.go` to validate quote cleanup and edge cases (single/double/backtick quotes and dangling quote scenarios).
- Fixed GitHub adapter usage in `internal/github/issues_adapter.go` by replacing `gh.Ptr(...)` with `gh.String(...)` to match `go-github v66` helpers.

### Testing
- Ran formatting with `gofmt -w` on modified files successfully.
- Ran `go test ./internal/config` and the new `sanitizeEnvValue` unit tests passed (`ok`).
- Ran `go test ./...` which failed in this environment due to missing `go.sum` entries for external modules (`github.com/spf13/cobra`, `github.com/google/go-github/v66/github`, `golang.org/x/oauth2`), not due to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c2d191ee48330aeb3b92409aca1fb)